### PR TITLE
Removes comma from end of line

### DIFF
--- a/bitcoin/dumbcoin/dumbcoin.ipynb
+++ b/bitcoin/dumbcoin/dumbcoin.ipynb
@@ -170,7 +170,7 @@
     "        nonce: The found nonce\n",
     "        niters: The number of iterations required to find the nonce\n",
     "    \"\"\"\n",
-    "    assert difficulty >= 1, \"Difficulty of 0 is not possible\"\n",
+    "    assert difficulty >= 1 \"Difficulty of 0 is not possible\"\n",
     "    i = 0\n",
     "    prefix = '1' * difficulty\n",
     "    while True:\n",


### PR DESCRIPTION
I believe there is an accidental comma at the end of the assert statement, which will cause a syntax error.