### PR TITLE
[dumbcoin] Fix wrong Wikipedia link to RSA article

### DIFF
--- a/bitcoin/dumbcoin/dumbcoin.ipynb
+++ b/bitcoin/dumbcoin/dumbcoin.ipynb
@@ -401,7 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In bitcoin a wallet is a private/public key pair. If you don't know what public/private key is, you should probably read about [RSA](https://en.wikipedia.org/wiki/RSA_(cryptosystem).\n",
+    "In bitcoin a wallet is a private/public key pair. If you don't know what public/private key is, you should probably read about [RSA](https://en.wikipedia.org/wiki/RSA_%28cryptosystem%29).\n",
     "\n",
     "The public key is used to receive transactions and the private key is used to spend money. By signing a transaction with our private key, anybody else can verify the signature using our public key.\n",
     "\n",


### PR DESCRIPTION
The closing parenthesis was missing. Therefore, the link didn't work.